### PR TITLE
Fix editorconfig to match code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,8 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = 2
-insert_final_newline = true
+indent_size = 4
+insert_final_newline = false
 trim_trailing_whitespace = true
 
 [*.md]


### PR DESCRIPTION
Not sure why there's an editorconfig file when it's not even being used, but these settings seem to match the actual code style. 