### PR TITLE
Fixing bug when mouseDown is true after leaving canvas

### DIFF
--- a/src/scripts/lib/BaseCanvas.js
+++ b/src/scripts/lib/BaseCanvas.js
@@ -164,6 +164,9 @@ var BaseCanvas = function (baseComponent, THREE, settings = {}) {
 
         handleMouseLease: function (event) {
             this.isUserInteracting = false;
+            if(this.mouseDown) {
+                this.mouseDown = false;
+            }
         },
 
         animate: function(){


### PR DESCRIPTION
This fixes the bug where if a user holds the mouse down and leaves the canvas and lets go, the plugin still acts as if the mouse button is down. 